### PR TITLE
Update print to logger.info

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,6 +1,7 @@
 import argparse
-import os
 import json
+import logging
+import os
 import time
 
 import torch
@@ -8,11 +9,12 @@ import torch
 from peft import LoraConfig, TaskType, get_peft_model
 from accelerate import Accelerator
 
-
 from gato.utils.utils import DotDict
 from gato.policy.gato_policy import GatoPolicy
 from gato.envs.setup_env import load_envs
 from gato.tasks.control_task import ControlTask
+
+logger = logging.getLogger(__name__)
 
 
 def main(args):
@@ -57,7 +59,7 @@ def main(args):
         )
         env_names.append(env.unwrapped.spec.id)
         tasks.append(task)
-    print('Evaluating on envs:', env_names)
+    logger.info('Evaluating on envs:', env_names)
 
     if len(args.text_datasets) > 0:
         # add text datasets
@@ -115,10 +117,10 @@ def main(args):
 
     logs['time/evaluation'] = time.time() - eval_start
 
-    print('=' * 80)
-    print(f'Evaluation results:')
+    logger.info('=' * 80)
+    logger.info(f'Evaluation results:')
     for k, v in logs.items():
-        print(f'{k}: {v}')
+        logger.info(f'{k}: {v}')
 
 
 if __name__ == '__main__':

--- a/gato/data/download_custom_datasets.py
+++ b/gato/data/download_custom_datasets.py
@@ -1,10 +1,8 @@
 import os
 import gdown
-
-# import logger
 import logging
+
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 datasets = {
     'd4rl_halfcheetah-expert-v2': 'https://drive.google.com/drive/folders/1YcUMTS7cMrUP8KJ6aQL87D9uYnrvGT02?usp=drive_link',
@@ -26,6 +24,6 @@ if __name__ == '__main__':
     for dataset_name, url in datasets.items():
         target_path = os.path.join(datasets_dir, dataset_name)
         if os.path.exists(target_path):
-            print(f'{dataset_name} already exists at {target_path}, skipping')
+            logger.info(f'{dataset_name} already exists at {target_path}, skipping')
             continue
         gdown.download_folder(url=url, output=target_path, quiet=False, use_cookies=False)

--- a/gato/envs/atari.py
+++ b/gato/envs/atari.py
@@ -2,11 +2,6 @@ import gymnasium as gym
 from gymnasium.wrappers import AtariPreprocessing, TransformReward 
 import numpy as np
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 def load_atari_env(env_name: str, load_kwargs: dict):
     assert 'v5' in env_name
 

--- a/gato/envs/setup_env.py
+++ b/gato/envs/setup_env.py
@@ -3,11 +3,6 @@ import gymnasium as gym
 
 from gato.envs.atari import load_atari_env, TRAIN_GAMES as ATARI_TRAIN, TEST_GAMES as ATARI_TEST
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 custom_env_loaders = {
     'ALE/': load_atari_env
 }

--- a/gato/policy/embeddings.py
+++ b/gato/policy/embeddings.py
@@ -4,11 +4,6 @@ from einops import rearrange
 
 import math
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 class ImageEmbedding(nn.Module):
     def __init__(
             self,

--- a/gato/policy/gato_policy.py
+++ b/gato/policy/gato_policy.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+import logging
 from typing import TYPE_CHECKING, Optional
+
 import torch
 import torch.nn as nn
-
 import gymnasium as gym
 import transformers
 from transformers import AutoTokenizer
@@ -12,10 +13,7 @@ from gato.transformers import GPT2Model
 from gato.policy.embeddings import ImageEmbedding
 from gato.policy.input_tokenizers import ContinuousTokenizer
 
-# import logger
-import logging
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 if TYPE_CHECKING:
     from gato.tasks.control_task import ControlTask
@@ -82,7 +80,7 @@ class GatoPolicy(nn.Module):
 
 
         if pretrained_lm is not None:
-            print(f'loading pretrained GPT2 weights')
+            logger.info(f'loading pretrained GPT2 weights')
             config = transformers.GPT2Config.from_pretrained(pretrained_lm)
             config.attn_pdrop = dropout # 0.1
             config.resid_pdrop = dropout

--- a/gato/policy/input_tokenizers.py
+++ b/gato/policy/input_tokenizers.py
@@ -2,11 +2,6 @@ import torch
 import torch.nn as nn
 import math
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 def mu_law(tensor, mu=100, M=256):
     return torch.sign(tensor) * torch.log(1 + mu * torch.abs(tensor)) / math.log(1 + mu*M) #torch.log(1 + mu*M)
 

--- a/gato/tasks/caption_task.py
+++ b/gato/tasks/caption_task.py
@@ -1,6 +1,7 @@
 # Assume all datasets are downloaded and available from local directories
 from gato.tasks.task import Task
 
+import logging
 import os
 import tarfile
 import webdataset as wds
@@ -18,10 +19,7 @@ import json
 import random
 from transformers import AutoTokenizer, GPT2Tokenizer
 
-# import logger
-import logging
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 class CaptionTask(Task): 
     def __init__(self, tokenizer_model:str, caption_dataset, train_data, test_data = [],
@@ -127,11 +125,11 @@ class CaptionTask(Task):
         total_tokens = 0
         
         if num_examples_to_test > len(self.dataset['test']):
-            print(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
+            logger.info(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
             num_examples_to_test = len(self.dataset['test'])
 
         if log_examples_to_output:
-            print(f'--- examples ---')
+            logger.info(f'--- examples ---')
 
         random_indices = [random.randint(0, len(self.dataset['test'])-1) for _ in range(num_examples_to_test)]
         selected_examples = [self.dataset['test'][idx] for idx in random_indices]
@@ -144,15 +142,15 @@ class CaptionTask(Task):
             # Generate prediction
             pred_logits, pred_caption = model.predict_caption(image, max_length = len(target_tokens),deterministic=deterministic)
             if log_examples_to_output and idx%10==0:
-                print(f'Target caption: {target_caption} \n Predicted caption : {pred_caption}')
-                print("----")
+                logger.info(f'Target caption: {target_caption} \n Predicted caption : {pred_caption}')
+                logger.info("----")
 
             # Calculate loss
             loss = loss_fn(pred_logits, torch.tensor(target_tokens).to(model.device))
             total_loss += loss.item()
             total_tokens += len(target_tokens)
         if log_examples_to_output:
-            print(f'--- examples end ---')
+            logger.info(f'--- examples end ---')
 
         avg_loss = total_loss / num_examples_to_test
         perplexity = torch.exp(torch.tensor(avg_loss))
@@ -169,13 +167,13 @@ if __name__ == '__main__':
     task = CaptionTask(tokenizer_model = 'gpt2', caption_dataset = '/home/<user name>/Git/NEKO/Caption_data', 
                        train_data = ['train'], test_data = ['test'], test_data_prop = 0.1)
 
-    #print(task.dataset["train"][4]["images"][0][1][10])
-    #print(task.dataset["train"][4]["images"][0][2][15])
-    #print(task.dataset["train"][4]["text"])
+    #logger.info(task.dataset["train"][4]["images"][0][1][10])
+    #logger.info(task.dataset["train"][4]["images"][0][2][15])
+    #logger.info(task.dataset["train"][4]["text"])
     batch = task.sample_batch(5)
-    #print(batch)
-    print(type(batch))
-    print(batch[0]['images'][0][1][10])
-    print(batch[0]['images'][0][2][15])
-    print(batch[0]['images'].shape)
-    print(batch[0]['text'])
+    #logger.info(batch)
+    logger.info(type(batch))
+    logger.info(batch[0]['images'][0][1][10])
+    logger.info(batch[0]['images'][0][2][15])
+    logger.info(batch[0]['images'].shape)
+    logger.info(batch[0]['text'])

--- a/gato/tasks/control_task.py
+++ b/gato/tasks/control_task.py
@@ -8,11 +8,6 @@ import minari
 from minari.dataset.minari_dataset import EpisodeData
 from gato.tasks.task import Task
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 if TYPE_CHECKING:
     from gato.policy.gato_policy import GatoPolicy
 

--- a/gato/tasks/task.py
+++ b/gato/tasks/task.py
@@ -1,10 +1,5 @@
 from abc import ABC
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 class Task(ABC):
     def sample_batch(self):
         raise NotImplementedError()

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 # supports dataset in huggingface datasets library for now
 from datasets import load_dataset, concatenate_datasets
 from gato.tasks.task import Task
+import logging
 import numpy as np
 from torch import nn
 from typing import TYPE_CHECKING, List,Dict
@@ -9,10 +10,7 @@ from transformers import AutoTokenizer
 import torch
 import copy
 
-# import logger
-import logging
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 if TYPE_CHECKING:
     from gato.policy.gato_policy import GatoPolicy
@@ -71,14 +69,14 @@ class TextTask(Task):
         total_tokens = 0
         
         if num_examples_to_test > len(self.text_dataset['test']):
-            print(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
+            logger.info(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
             num_examples_to_test = len(self.text_dataset['test'])
 
         if log_examples_to_output:
-            print(f'--- examples ---')
+            logger.info(f'--- examples ---')
         
         batch_dicts = self.sample_batch(num_examples_to_test, is_test=True)
-        print(f'Num of examples to test : {num_examples_to_test} | Actual batch size of test data : {len(batch_dicts)}')
+        logger.info(f'Num of examples to test : {num_examples_to_test} | Actual batch size of test data : {len(batch_dicts)}')
         
         actual_examples_tested = 0
         for idx in range(min(num_examples_to_test, len(batch_dicts))):
@@ -97,8 +95,8 @@ class TextTask(Task):
             pred_logits, pred_tokens = model.predict_text(new_batch_dict, max_length=len(target_tokens), deterministic=deterministic)
             # todo: pull 50 into a CLI argument in train.py
             if log_examples_to_output and idx%50==0:
-                print(f'Text Example : {tokenizer.decode(batch_dict["text"])} \n Input passed to model : {tokenizer.decode(new_batch_dict["text"])} \n Predicted output : {tokenizer.decode(pred_tokens)}')
-                print("----")
+                logger.info(f'Text Example : {tokenizer.decode(batch_dict["text"])} \n Input passed to model : {tokenizer.decode(new_batch_dict["text"])} \n Predicted output : {tokenizer.decode(pred_tokens)}')
+                logger.info("----")
 
             # Calculate loss
             target_tokens = torch.Tensor(target_tokens).long()
@@ -107,7 +105,7 @@ class TextTask(Task):
             total_tokens += len(target_tokens)
             actual_examples_tested += 1
         if log_examples_to_output:
-            print(f'--- examples end ---')
+            logger.info(f'--- examples end ---')
 
         avg_loss = total_loss / actual_examples_tested
         perplexity = torch.exp(torch.tensor(avg_loss))

--- a/gato/tasks/vqa_task.py
+++ b/gato/tasks/vqa_task.py
@@ -1,6 +1,7 @@
 # Assume all datasets are downloaded and available from local directories
 from gato.tasks.task import Task
 
+import logging
 import os
 from PIL import Image
 import io # need to use BytesIO
@@ -14,10 +15,7 @@ import json
 import random
 from transformers import AutoTokenizer, GPT2Tokenizer
 
-# import logger
-import logging
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 class VqaTask(Task): 
     def __init__(self, tokenizer_model:str,
@@ -109,11 +107,11 @@ class VqaTask(Task):
         total_tokens = 0
         
         if num_examples_to_test > len(self.dataset['test']):
-            print(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
+            logger.info(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
             num_examples_to_test = len(self.dataset['test'])
 
         if log_examples_to_output:
-            print(f'--- examples ---')
+            logger.info(f'--- examples ---')
 
         random_indices = [random.randint(0, len(self.dataset['test'])-1) for _ in range(num_examples_to_test)]
         selected_examples = [self.dataset['test'][idx] for idx in random_indices]
@@ -128,15 +126,15 @@ class VqaTask(Task):
             # Generate prediction
             pred_logits, pred_answer = model.predict_answer(image, question, max_length = len(target_tokens),deterministic=deterministic)
             if log_examples_to_output and idx%10==0:
-                print(f'Target answer: {target_answer} \n Predicted answer : {pred_answer}')
-                print("----")
+                logger.info(f'Target answer: {target_answer} \n Predicted answer : {pred_answer}')
+                logger.info("----")
 
             # Calculate loss
             loss = loss_fn(pred_logits, torch.tensor(target_tokens).to(model.device))
             total_loss += loss.item()
             total_tokens += len(target_tokens)
         if log_examples_to_output:
-            print(f'--- examples end ---')
+            logger.info(f'--- examples end ---')
 
         avg_loss = total_loss / num_examples_to_test
         perplexity = torch.exp(torch.tensor(avg_loss))
@@ -163,10 +161,9 @@ if __name__ == '__main__':
                    )
 
     batch = task.sample_batch(5)
-    print(type(batch))
-    print(list(batch[0].keys()))
-    print(batch[0]['images'][0][1][10])
-    print(batch[0]['images'][0][2][15])
-    print(batch[0]['images'].shape)
-    print(batch[0]['text'])
-
+    logger.info(type(batch))
+    logger.info(list(batch[0].keys()))
+    logger.info(batch[0]['images'][0][1][10])
+    logger.info(batch[0]['images'][0][2][15])
+    logger.info(batch[0]['images'].shape)
+    logger.info(batch[0]['text'])

--- a/gato/training/schedulers.py
+++ b/gato/training/schedulers.py
@@ -5,11 +5,6 @@ import numpy as np
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 def get_linear_warmup_cosine_decay_scheduler(optimizer: Optimizer, num_warmup_steps: int, num_training_steps: int, base_lr: float, init_lr: float, min_lr: float , cosine_decay: bool = True, last_epoch=-1):
 
     lr_lambda = partial(

--- a/gato/training/trainer.py
+++ b/gato/training/trainer.py
@@ -1,3 +1,4 @@
+import logging
 import time
 import os
 
@@ -11,10 +12,7 @@ from gato.tasks.vqa_task import VqaTask
 
 from gato.utils.utils import save_model
 
-# import logger
-import logging
 logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
 
 class Trainer:
     def __init__(
@@ -113,11 +111,11 @@ class Trainer:
 
         if self.accelerator.is_main_process:
             if self.print_logs:
-                print('=' * 80)
-                print(f'Iteration {iter}')
+                logger.info('=' * 80)
+                logger.info(f'Iteration {iter}')
                 for k, v in logs.items():
-                    print(f'{k}: {v}')
-                print('=' * 80)
+                    logger.info(f'{k}: {v}')
+                logger.info('=' * 80)
 
         ## Save model
         if self.args.save_model and self.args.save_mode == 'checkpoint':

--- a/gato/utils/utils.py
+++ b/gato/utils/utils.py
@@ -4,11 +4,6 @@ from copy import deepcopy
 
 import torch
 
-# import logger
-import logging
-logger = logging.getLogger(__name__)
-# Example of use logger.debug(f'foobar')
-
 class DotDict(dict):
     """dot.notation access to dictionary attributes"""
 

--- a/train.py
+++ b/train.py
@@ -1,5 +1,5 @@
 import argparse
-import random
+import logging
 import os
 from datetime import datetime
 
@@ -20,6 +20,8 @@ from gato.tasks.control_task import ControlTask
 from gato.tasks.text_task import TextTask
 from gato.tasks.caption_task import CaptionTask
 from gato.tasks.vqa_task import VqaTask
+
+logger = logging.getLogger(__name__)
 
 
 def main(args):
@@ -101,12 +103,12 @@ def main(args):
 
     if args.init_checkpoint is not None:
         with accelerator.main_process_first():
-            print('Loading model from checkpoint:', args.init_checkpoint)
+            logger.info('Loading model from checkpoint:', args.init_checkpoint)
             model.load_state_dict(torch.load(args.init_checkpoint, map_location=args.device))
 
     # print trainable parameters
     params = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    print('Trainable Parameters:', '{}M'.format(params / 1e6))
+    logger.info('Trainable Parameters:', '{}M'.format(params / 1e6))
     args.trainable_params = params
 
 


### PR DESCRIPTION
Also removes logging imports from files that don't do any logging and removes the example comment. Both of those changes are just minor non-functional changes to reduce the number of lines of non-functional code. The logging module is standard to python and there are plenty of examples in the official Python docs, so I don't think we gain much by including examples in each file.